### PR TITLE
Rename BicubicDogWay, add BicubicZoptiNeutral

### DIFF
--- a/vskernels/kernels.py
+++ b/vskernels/kernels.py
@@ -14,12 +14,11 @@ core = vs.core
 
 
 __all__: List[str] = [
-    'Bicubic', 'Bilinear', 'FmtConv', 'Lanczos', 'Point', 'Spline16', 'Spline36', 'Spline64',
-    'Bessel', 'BicubicDidee', 'BicubicZopti', 'BicubicZoptiNeutral', 'BicubicSharp', 'BlackHarris', 'BlackMan', 'BlackManMinLobe',
-    'BlackNuttall', 'Bohman', 'Box', 'BSpline', 'Catrom', 'Cosine', 'FlatTop', 'Gaussian', 'Ginseng', 'Hamming',
-    'Hann', 'Hermite', 'Impulse', 'Kaiser', 'MinSide', 'Mitchell', 'NearestNeighbour', 'Parzen', 'Point', 'Quadratic',
-    'Robidoux', 'RobidouxSharp', 'RobidouxSoft', 'Sinc', 'Welch', 'Wiener',
-    'get_all_kernels', 'get_kernel', 'Kernel'
+    'Bicubic', 'Bilinear', 'FmtConv', 'Lanczos', 'Point', 'Spline16', 'Spline36', 'Spline64', 'Bessel', 'BicubicDidee',
+    'BicubicZopti', 'BicubicZoptiNeutral', 'BicubicSharp', 'BlackHarris', 'BlackMan', 'BlackManMinLobe', 'BlackNuttall',
+    'Bohman', 'Box', 'BSpline', 'Catrom', 'Cosine', 'FlatTop', 'Gaussian', 'Ginseng', 'Hamming', 'Hann', 'Hermite',
+    'Impulse', 'Kaiser', 'MinSide', 'Mitchell', 'NearestNeighbour', 'Parzen', 'Point', 'Quadratic', 'Robidoux',
+    'RobidouxSharp', 'RobidouxSoft', 'Sinc', 'Welch', 'Wiener', 'get_all_kernels', 'get_kernel', 'Kernel'
 ]
 
 

--- a/vskernels/kernels.py
+++ b/vskernels/kernels.py
@@ -492,15 +492,15 @@ class BicubicZopti(Bicubic):
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(b=-0.6, c=0.4, **kwargs)
-        
+
 
 class BicubicZoptiNeutral(Bicubic):
     """
     Kernel inspired by Zopti.
     Bicubic b=-0.6, c=0.3
-    
+
     Slightly more netural than BicubicZopti
-    
+
     Follows `b + 2c = 0` for downscaling opposed to `b + 2c = 1` for upscaling.
     """
 

--- a/vskernels/kernels.py
+++ b/vskernels/kernels.py
@@ -468,14 +468,13 @@ class BicubicAuto(Bicubic):
 
 class BicubicDidee(Bicubic):
     """
-    Kernel inspired by a Didée post.
-
-    `See this doom9 post for further information <https://web.archive.org/web/20220713044016/https://forum.doom9.org/showpost.php?p=1579385&postcount=25>`_.
+    Kernel inspired by a Didée post.\n
+    `See this doom9 post for further information
+    <https://web.archive.org/web/20220713044016/https://forum.doom9.org/showpost.php?p=1579385&postcount=25>`_.
 
     Bicubic b=-0.5, c=0.25
+    This is useful for downscaling content, but might not help much with upscaling.
 
-    This is useful for downscaling content, but might not help much with upscaling. 
-    
     Follows `b + 2c = 0` for downscaling opposed to `b + 2c = 1` for upscaling.
     """
 
@@ -486,11 +485,8 @@ class BicubicDidee(Bicubic):
 class BicubicZopti(Bicubic):
     """
     Kernel optimized by Zopti.
-
     `See this doom9 post for further information <https://forum.doom9.org/showthread.php?p=1865218#post1865218>`_.
-
     Bicubic b=-0.6, c=0.4
-
     Optimized for 2160p to 720p (by Boulder). Beware, not neutral. Adds some local contrast.
     """
 
@@ -501,7 +497,6 @@ class BicubicZopti(Bicubic):
 class BicubicZoptiNeutral(Bicubic):
     """
     Kernel inspired by Zopti.
-
     Bicubic b=-0.6, c=0.3
     
     Slightly more netural than BicubicZopti

--- a/vskernels/kernels.py
+++ b/vskernels/kernels.py
@@ -15,7 +15,7 @@ core = vs.core
 
 __all__: List[str] = [
     'Bicubic', 'Bilinear', 'FmtConv', 'Lanczos', 'Point', 'Spline16', 'Spline36', 'Spline64',
-    'Bessel', 'BicubicDidee', 'BicubicDogWay', 'BicubicSharp', 'BlackHarris', 'BlackMan', 'BlackManMinLobe',
+    'Bessel', 'BicubicDidee', 'BicubicZopti', 'BicubicZoptiNeutral', 'BicubicSharp', 'BlackHarris', 'BlackMan', 'BlackManMinLobe',
     'BlackNuttall', 'Bohman', 'Box', 'BSpline', 'Catrom', 'Cosine', 'FlatTop', 'Gaussian', 'Ginseng', 'Hamming',
     'Hann', 'Hermite', 'Impulse', 'Kaiser', 'MinSide', 'Mitchell', 'NearestNeighbour', 'Parzen', 'Point', 'Quadratic',
     'Robidoux', 'RobidouxSharp', 'RobidouxSoft', 'Sinc', 'Welch', 'Wiener',
@@ -422,28 +422,47 @@ class BicubicDidee(Bicubic):
     """
     Kernel inspired by a Didée post.
 
-    `See this doom9 post for further information <https://forum.doom9.org/showthread.php?p=1748922#post1748922>`_.
+    `See this doom9 post for further information <https://web.archive.org/web/20220713044016/https://forum.doom9.org/showpost.php?p=1579385&postcount=25>`_.
 
     Bicubic b=-0.5, c=0.25
 
-    This is useful for downscaling content, but might not help much with upscaling.
+    This is useful for downscaling content, but might not help much with upscaling. 
+    
+    Follows `b + 2c = 0` for downscaling opposed to `b + 2c = 1` for upscaling.
     """
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(b=-1/2, c=1/4, **kwargs)
 
 
-class BicubicDogWay(Bicubic):
+class BicubicZopti(Bicubic):
     """
-    Kernel inspired by DogWay.
+    Kernel optimized by Zopti.
+
+    `See this doom9 post for further information <https://forum.doom9.org/showthread.php?p=1865218#post1865218>`_.
 
     Bicubic b=-0.6, c=0.4
 
-    This is useful for downscaling content with ringing.
+    Optimized for 2160p to 720p (by Boulder). Beware, not neutral. Adds some local contrast.
     """
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(b=-0.6, c=0.4, **kwargs)
+        
+
+class BicubicZoptiNeutral(Bicubic):
+    """
+    Kernel inspired by Zopti.
+
+    Bicubic b=-0.6, c=0.3
+    
+    Slightly more netural than BicubicZopti
+    
+    Follows `b + 2c = 0` for downscaling opposed to `b + 2c = 1` for upscaling.
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(b=-0.6, c=0.3, **kwargs)
 
 
 class FmtConv(Kernel):


### PR DESCRIPTION
BicubicDogWay is actually a kernel calculated by another user with a tool called Zopti: https://github.com/Dogway/Avisynth-Scripts/blob/128dec0445ba1c48850047947beca0c307bea35f/TransformsPack%20-%20Main.avsi#L1674

Zopti is used to brute-force settings for scripts and presents objective measurements.

BicubicZoptiNeutral is just the aforementioned but modified slightly to follow `b + 2c = 0`.

Replaced the link to Didee's post on Doom9 with a better one that describes `b + 2c = 0`, also archived.

Did not use an archived link for the zopti kernel since it's not grabbing the graphs. However a text only version is available for future travelers https://web.archive.org/web/20220713052853/https://forum.doom9.org/showthread.php?p=1865218%23post1865218

