### PR TITLE
Use noncustom kernel when possible

### DIFF
--- a/vskernels/kernels/complex.py
+++ b/vskernels/kernels/complex.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from math import ceil
-from typing import TYPE_CHECKING, Any, SupportsFloat, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, SupportsFloat, TypeVar, Union, cast, override
 
 from stgpytools import inject_kwargs_params
 from vstools import (
@@ -260,6 +260,13 @@ class CustomComplexTapsKernel(CustomComplexKernel):
     @inject_self.cached.property
     def kernel_radius(self) -> int:  # type: ignore
         return ceil(self.taps)
+
+    @override
+    def get_params_args(
+        self, is_descale: bool, clip: vs.VideoNode, width: int | None = None, height: int | None = None, **kwargs: Any
+    ) -> dict[str, Any]:
+        args = super().get_params_args(is_descale, clip, width, height, **kwargs)
+        return args | {'taps': self.taps} if is_descale else args | {'filter_param_a': self.taps}
 
 
 ComplexScalerT = Union[str, type[ComplexScaler], ComplexScaler]

--- a/vskernels/kernels/spline.py
+++ b/vskernels/kernels/spline.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from math import comb
 from typing import Any
 
-from vstools import inject_self
+from vstools import core, inject_self
 
 from .complex import CustomComplexTapsKernel
 from .helpers import poly3
@@ -106,6 +106,8 @@ class NaturalSpline(Spline):
 class Spline16(NaturalSpline):
     """Spline16 resizer."""
 
+    descale_function = core.lazy.descale.Despline16
+    _no_blur_scale_function = core.lazy.resize2.Spline16
     _static_kernel_radius = 2
 
     _static_coeffs = [
@@ -117,6 +119,8 @@ class Spline16(NaturalSpline):
 class Spline36(NaturalSpline):
     """Spline36 resizer."""
 
+    descale_function = core.lazy.descale.Despline36
+    _no_blur_scale_function = core.lazy.resize2.Spline36
     _static_kernel_radius = 3
 
     _static_coeffs = [
@@ -129,6 +133,8 @@ class Spline36(NaturalSpline):
 class Spline64(NaturalSpline):
     """Spline64 resizer."""
 
+    descale_function = core.lazy.descale.Despline64
+    _no_blur_scale_function = core.lazy.resize2.Spline64
     _static_kernel_radius = 4
 
     _static_coeffs = [

--- a/vskernels/kernels/various.py
+++ b/vskernels/kernels/various.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from math import cos, exp, log, pi, sqrt
-from typing import Any
+from typing import Any, override
 
-from vstools import inject_self
+from vstools import core, inject_self
 
 from .complex import CustomComplexKernel, CustomComplexTapsKernel
 from .helpers import sinc
@@ -62,9 +62,12 @@ class Point(CustomComplexKernel):
 class Bilinear(CustomComplexKernel):
     """Bilinear resizer."""
 
+    descale_function = core.lazy.descale.Debilinear  # type: ignore[assignment]
+    _no_blur_scale_function = core.lazy.resize2.Bilinear
     _static_kernel_radius = 1
 
     @inject_self.cached
+    @override
     def kernel(self, *, x: float) -> float:
         return max(1.0 - abs(x), 0.0)
 
@@ -76,10 +79,14 @@ class Lanczos(CustomComplexTapsKernel):
     :param taps: taps param for lanczos kernel
     """
 
+    descale_function = core.lazy.descale.Delanczos  # type: ignore[assignment]
+    _no_blur_scale_function = core.lazy.resize2.Lanczos
+
     def __init__(self, taps: float = 3, **kwargs: Any) -> None:
         super().__init__(taps, **kwargs)
 
     @inject_self.cached
+    @override
     def kernel(self, *, x: float) -> float:
         x, taps = abs(x), self.kernel_radius
 


### PR DESCRIPTION
`descale.Decustom` init is slow and AFAICT it's only being used for symmetry with `resize2.Custom`, which itself was introduced to enable setting `blur` (am I missing something else?). If that's the case, then everything is being made slower just for the (probably) few cases of blur usage. This hurts the native-res plugin especially.

With this change, things work like so:

1. If descaling, always use `descale.Debicubic`/`descale.Debilinear`. They support `blur` so there should be no need for custom kernels.
2. If scaling/resampling, use `resize2.Bicubic`/`resize2.Bilinear` if `blur` is not set to the default of 1.0. This isn't here to speed anything up, rather it just seems like a good idea to use the plugin's available filters when possible instead of custom ones.
3. Otherwise, use the slower custom kernels since blur is needed and not provided by the plugin.

With this, native-res execution (height [502, 999], step size 1, Catrom) goes from ~3 minutes to ~30 seconds. If we like this approach and it works well then we can bring it to the other kernels.